### PR TITLE
 Fix nil pointer stopping non-existing server

### DIFF
--- a/cmd/hcloud_server/main.go
+++ b/cmd/hcloud_server/main.go
@@ -168,6 +168,10 @@ func (m *module) present(ctx context.Context) (resp ansible.ModuleResponse, err 
 			if server, _, err = m.client.Server.GetByID(ctx, id); err != nil {
 				return
 			}
+			if server == nil {
+				err = fmt.Errorf("Server with id %d not found", id)
+				return
+			}
 			if err = m.ensureServerState(ctx, &resp, server, ""); err != nil {
 				return
 			}


### PR DESCRIPTION
Hey @thetechnick ,

Got the following crash when trying to use a id that does not exist
or is obviously not mine. See output below.

This merge request contains a test and a proposed fix.

```
    ansible localhost -m hcloud_server -a 'state=stopped id=1'
    localhost | FAILED! => {
        "changed": false,
        "module_stderr": "panic: runtime error: invalid memory address or nil pointer dereference\n[signal SIGSEGV: segmentation violation code=0x1 addr=0xf8 pc=0x62b88a]\n\n
        goroutine 5 [running]:\nmain.(*module).ensureServerState(0xc420100000, 0x7042a0, 0xc4200160f0, 0xc4200e6520, 0x0, 0x0, 0x0, 0x0, 0x0)\n\t/home/nschieder/Projects/go/src/github.com/thetechnick/hcloud-ansible/cmd/hcloud_server/main.go:289 +0x3a\nmain.(*module).present.func2(0xc420016760, 0xc420016750, 0xc4200e6540, 0xc420100000, 0xc4200e6520, 0x7042a0, 0xc4200160f0, 0x1, 0x0, 0x0)\n\t/home/nschieder/Projects/go/src/github.com/thetechnick/hcloud-ansible/cmd/hcloud_server/main.go:171 +0x142\ncreated by main.(*module).present\n\t/home/nschieder/Projects/go/src/github.com/thetechnick/hcloud-ansible/cmd/hcloud_server/main.go:158 +0x27d\n",
        "module_stdout": "",
        "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
        "rc": 2
    }
```